### PR TITLE
Improve OOBE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:3.0.2
+# A distro upgrade requires changes here and in docker-prereqs.sh
+FROM ruby:3.0.2-buster
 
 COPY Gemfile* /tmp/
 COPY docker-prereqs.sh /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # A distro upgrade requires changes here and in docker-prereqs.sh
-FROM ruby:3.0.2-buster
+FROM ruby:3.0.2-bullseye
 
 COPY Gemfile* /tmp/
 COPY docker-prereqs.sh /tmp/

--- a/README.md
+++ b/README.md
@@ -17,17 +17,20 @@ You'll need the Docker [toolbox](https://www.docker.com/docker-toolbox).  I (Joe
 
 ### Configuration
 * Create a `secrets.yml` file based on the `secrets_example.yml` file. The tokens are just random hex strings. You can generate a secret using `rails secret`.
+* Create a `master.key` file adjacent to `secrets.yml` (in the `/config` directory) containing a sufficiently long random hex string. Consider using `rails secret` to generate.
 * If you want to run with local changes (so that you can change the Ruby code and not have to rebuild the world each time), modify docker-compose accordingly:
 ```
   volumes:   # Remove this for production use
-   - /Users/Joey/twitarr:/srv/app
+   - ./:/srv/app
 ```
 
 ### Building the docker images
 Run:
 ```
-   $ docker-compose build
+   $ docker-compose build [--no-cache]
    $ docker-compose up
+   # When you're done
+   $ docker-compose down [-v]
 ```
 
 This will create a docker image based on ruby, as well as download a postgres image.
@@ -43,6 +46,11 @@ Once it completes you should be able to reach twitarr via http://localhost:3000.
 
    ```
    sudo apt-get install git gnupg2 curl imagemagick libmagickwand-dev libidn11-dev libpq-dev postgresql postgresql-contrib nodejs
+   ```
+   
+   Fedora 34:
+   ```
+   sudo dnf install git gnupg2 curl imagemagick ImageMagick-devel libidn-devel libpq-devel postgresql postgresql-contrib nodejs
    ```
 2. Set your postgres password
 

--- a/config/environments/docker.rb
+++ b/config/environments/docker.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
-  config.secure_cookies = true
+  config.secure_cookies = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/secrets_example.yml
+++ b/config/secrets_example.yml
@@ -1,3 +1,7 @@
+docker:
+  secret_key_base: SECRET_KEY_HERE
+  initial_admin_password: ADMIN_PASS_HERE
+
 development:
   secret_key_base: SECRET_KEY_HERE
   initial_admin_password: ADMIN_PASS_HERE

--- a/docker-prereqs.sh
+++ b/docker-prereqs.sh
@@ -1,3 +1,3 @@
 curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list
+echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list
 apt-get update && apt-get install -y libidn11-dev libmagickwand-dev build-essential postgresql-client-13 libpq-dev nodejs


### PR DESCRIPTION
This contains several fixes/enhancements to improve the Out-Of-Box-Experience of Twitarr.
* Upgrade and lock ruby-3.0.2 to Debian Bullseye image. The ruby version has not changed but the base image OS version has.
* Minor notes on README for basic `docker-compose` tasks and for Fedora dependencies.
* Update `secrets_example.yml` to include docker runtime environment.
* Disable secure cookies for docker runtime, preventing login.

The last one is somewhat ideologically complex given the mantra of "disabling security is bad". However a change introduced in a prior commit broke login for anything not running behind an HTTPS ingress router. Thus I believe this to be necessary.

This PR does not solve a transient runtime issue related to `ember-template-compiler` and `rails assets:precompile` which is still ongoing with little success. With enough brute force it usually works after a couple of restarts.